### PR TITLE
Reindex all SYNCED information types in Postgres to Elasticsearch.

### DIFF
--- a/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/elasticsearch/ElasticsearchStatus.java
+++ b/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/elasticsearch/ElasticsearchStatus.java
@@ -4,5 +4,5 @@ public enum ElasticsearchStatus {
 	TO_BE_CREATED,
 	TO_BE_UPDATED,
 	TO_BE_DELETED,
-	SYNCHED
+	SYNCED
 }

--- a/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationTypeRepository.java
+++ b/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationTypeRepository.java
@@ -2,15 +2,21 @@ package no.nav.data.catalog.backend.app.informationtype;
 
 import no.nav.data.catalog.backend.app.elasticsearch.ElasticsearchStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
+import static no.nav.data.catalog.backend.app.elasticsearch.ElasticsearchStatus.SYNCED;
+
 public interface InformationTypeRepository extends JpaRepository<InformationType, Long> {
+	ElasticsearchStatus synchedStatus = SYNCED;
 	List<InformationType> findAllByOrderByIdAsc();
 
 	Optional<List<InformationType>> findByElasticsearchStatus(@Param("status") ElasticsearchStatus status);
 	Optional<InformationType> findByName(@Param("name") String name);
 
+	@Query("UPDATE InformationType SET elasticsearchStatus = :status WHERE status = SYNCED")
+	int updateStatusAllRows(@Param("status") ElasticsearchStatus status);
 }

--- a/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationTypeService.java
+++ b/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationTypeService.java
@@ -46,7 +46,7 @@ public class InformationTypeService {
 				elasticsearch.insertInformationType(jsonMap);
 
 				// informationType.setJsonString(jsonMap.toString());
-				informationType.setElasticsearchStatus(SYNCHED);
+				informationType.setElasticsearchStatus(SYNCED);
 				repository.save(informationType);
 			}
 		}
@@ -63,7 +63,7 @@ public class InformationTypeService {
 				elasticsearch.updateInformationTypeById(informationType.getElasticsearchId(), jsonMap);
 
 				// informationType.setJsonString(jsonMap.toString());
-				informationType.setElasticsearchStatus(SYNCHED);
+				informationType.setElasticsearchStatus(SYNCED);
 				repository.save(informationType);
 			}
 		}
@@ -82,7 +82,9 @@ public class InformationTypeService {
 		}
 	}
 
-	//TODO: resendToElasticsearch()
+	public void resendToElasticsearch() {
+		repository.updateStatusAllRows(TO_BE_UPDATED);
+	}
 
 	public void validateRequest(InformationTypeRequest request, boolean isUpdate) throws ValidationException {
 		HashMap<String, String> validationErrors = new HashMap<>();

--- a/data-catalog-backend-test/data-catalog-backend-test-component/src/test/java/no/nav/data/catalog/backend/test/component/InformationTypeServiceTest.java
+++ b/data-catalog-backend-test/data-catalog-backend-test-component/src/test/java/no/nav/data/catalog/backend/test/component/InformationTypeServiceTest.java
@@ -7,6 +7,7 @@ import no.nav.data.catalog.backend.app.informationtype.InformationType;
 import no.nav.data.catalog.backend.app.informationtype.InformationTypeRepository;
 import no.nav.data.catalog.backend.app.informationtype.InformationTypeRequest;
 import no.nav.data.catalog.backend.app.informationtype.InformationTypeService;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -38,6 +39,9 @@ public class InformationTypeServiceTest {
 
     @Mock
     private ElasticsearchRepository elasticsearchRepository;
+
+    @Mock
+    private RestHighLevelClient highLevelClient;
 
 	@InjectMocks
 	private InformationTypeService informationTypeService;


### PR DESCRIPTION
Changed logic to automatically index documents not found in Elasticsearch instead of throwing exception.