### PR TITLE
InformationType uses several sources

### DIFF
--- a/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationType.java
+++ b/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationType.java
@@ -23,6 +23,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Entity
 @Data
@@ -88,7 +89,7 @@ public class InformationType extends Auditable<String> {
 		}
 		this.name = request.getName();
 		this.categoryCode = request.getCategoryCode().toUpperCase();
-		this.producerCode = request.getProducerCode().toUpperCase();
+		this.producerCode = request.getProducerCode().stream().map(String::toUpperCase).collect(Collectors.joining(", "));
 		this.systemCode = request.getSystemCode().toUpperCase();
 		this.description = request.getDescription();
 		this.personalData = request.getPersonalData();

--- a/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationTypeRequest.java
+++ b/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationTypeRequest.java
@@ -29,7 +29,7 @@ public class InformationTypeRequest {
 
 	private String name;
 	private String categoryCode;
-	private String producerCode;
+	private List<String> producerCode;
 	private String systemCode;
 	private String description;
 	private Boolean personalData;

--- a/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationTypeResponse.java
+++ b/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationTypeResponse.java
@@ -8,8 +8,11 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import no.nav.data.catalog.backend.app.codelist.ListName;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Data
 @NoArgsConstructor
@@ -22,7 +25,7 @@ public class InformationTypeResponse {
 	private String name;
 	private String description;
 	private Map category;
-	private Map producer;
+	private List<Map> producer;
 	private Map system;
 	private Boolean personalData;
 
@@ -33,9 +36,16 @@ public class InformationTypeResponse {
 		this.name = informationType.getName();
 		this.description = informationType.getDescription();
 		this.category = getMapForCodelistItem(ListName.CATEGORY, informationType.getCategoryCode());
-		this.producer = getMapForCodelistItem(ListName.PRODUCER, informationType.getProducerCode());
+		this.producer = getListOfMappedProducers(informationType.getProducerCode());
 		this.system = getMapForCodelistItem(ListName.SYSTEM, informationType.getSystemCode());
 		this.personalData = informationType.isPersonalData();
+	}
+
+	private List<Map> getListOfMappedProducers(String commaSeparatedStringOfProducerCodes) {
+		List<String> listOfProducerCodes = Arrays.asList(commaSeparatedStringOfProducerCodes.split("\\s*,\\s*"));
+		return listOfProducerCodes.stream()
+				.map(producerCode -> getMapForCodelistItem(ListName.PRODUCER, producerCode))
+				.collect(Collectors.toList());
 	}
 
 	private Map<String, String> getMapForCodelistItem(ListName listName, String code) {

--- a/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationTypeService.java
+++ b/data-catalog-backend-app/src/main/java/no/nav/data/catalog/backend/app/informationtype/InformationTypeService.java
@@ -118,8 +118,8 @@ public class InformationTypeService {
 		String codeType = listName.toString().toLowerCase() + "Code";
 		if (code == null) {
 			validationErrors.put(codeType, String.format("The %s was null", codeType));
-		} else if (!codelists.get(listName).containsKey(code)) {
-			validationErrors.put(codeType, String.format("The code:%s was not found in the codelist:%s", code, listName));
+		} else if (!codelists.get(listName).containsKey(code.toUpperCase())) {
+			validationErrors.put(codeType, String.format("The code:%s was not found in the codelist:%s", code.toUpperCase(), listName));
 		}
 	}
 }

--- a/data-catalog-backend-test/data-catalog-backend-test-component/src/test/java/no/nav/data/catalog/backend/test/component/informationtype/InformationTypeControllerTest.java
+++ b/data-catalog-backend-test/data-catalog-backend-test-component/src/test/java/no/nav/data/catalog/backend/test/component/informationtype/InformationTypeControllerTest.java
@@ -3,8 +3,9 @@ package no.nav.data.catalog.backend.test.component.informationtype;
 import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.CATEGORY_CODE;
 import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.CATEGORY_DESCRIPTION;
 import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.DESCRIPTION;
-import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.PRODUCER_CODE;
-import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.PRODUCER_DESCRIPTION;
+import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.PRODUCER_CODE_LIST;
+import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.PRODUCER_CODE_STRING;
+import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.PRODUCER_DESCRIPTION_LIST;
 import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.SYSTEM_CODE;
 import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.SYSTEM_DESCRIPTION;
 import static no.nav.data.catalog.backend.test.component.informationtype.TestdataInformationTypes.URL;
@@ -85,8 +86,44 @@ public class InformationTypeControllerTest {
 		codelists.put(ListName.SYSTEM, new HashMap<>());
 
 		codelists.get(ListName.CATEGORY).put(CATEGORY_CODE, CATEGORY_DESCRIPTION);
-		codelists.get(ListName.PRODUCER).put(PRODUCER_CODE, PRODUCER_DESCRIPTION);
+		codelists.get(ListName.PRODUCER).put(PRODUCER_CODE_LIST.get(0), PRODUCER_DESCRIPTION_LIST.get(0));
+		codelists.get(ListName.PRODUCER).put(PRODUCER_CODE_LIST.get(1), PRODUCER_DESCRIPTION_LIST.get(1));
 		codelists.get(ListName.SYSTEM).put(SYSTEM_CODE, SYSTEM_DESCRIPTION);
+	}
+
+	@Test
+	public void test() {
+		InformationTypeRequest request = InformationTypeRequest.builder()
+				.name("testProducerList")
+				.categoryCode(CATEGORY_CODE)
+				.producerCode(List.of("Skatteetaten", "bruker"))
+				.systemCode(SYSTEM_CODE)
+				.description(DESCRIPTION)
+				.personalData(true)
+				.build();
+		InformationType informationType = new InformationType().convertFromRequest(request, false);
+
+		InformationTypeResponse response = informationType.convertToResponse();
+
+
+//
+//		List<InformationType> informationTypes = createTestdataInformationType(20);
+//		List<InformationTypeResponse> informationTypesResponses = informationTypes.stream()
+//				.map(InformationType::convertToResponse)
+//				.collect(Collectors.toList());
+//		RestResponsePage<InformationTypeResponse> informationTypePage = new RestResponsePage<>(informationTypesResponses);
+//
+//		given(repository.findAllByOrderByIdAsc(PageRequest.of(0, 20))).willReturn(informationTypes);
+//
+//		mvc.perform(get("/backend/informationtype")
+//				.contentType(MediaType.APPLICATION_JSON))
+//				.andExpect(status().isOk())
+//				.andExpect(jsonPath("$.totalElements", is(20)))
+//				.andExpect(jsonPath("$.content", hasSize(20)));
+//
+//
+//				createInformationTypeRequestTestData("testProducerList");
+
 	}
 
 	@Test
@@ -157,7 +194,7 @@ public class InformationTypeControllerTest {
 	}
 
 	@Test
-	public void createInformationType_shouldFailToCreateNewInformationType_WithInvalidValidRequest() throws Exception {
+	public void createInformationType_shouldFailToCreateNewInformationType_WithInvalidValidRequest() {
 		List<InformationTypeRequest> requests = List.of(InformationTypeRequest.builder().build());
 		HashMap<String, String> validationErrors = new HashMap<>();
 
@@ -255,7 +292,7 @@ public class InformationTypeControllerTest {
 				.name(name)
 				.description(DESCRIPTION)
 				.categoryCode(CATEGORY_CODE)
-				.producerCode(PRODUCER_CODE)
+				.producerCode(PRODUCER_CODE_STRING)
 				.systemCode(SYSTEM_CODE)
 				.personalData(true)
 				.elasticsearchId("esId")
@@ -267,7 +304,7 @@ public class InformationTypeControllerTest {
 		return InformationTypeRequest.builder()
 				.name(name)
 				.categoryCode(CATEGORY_CODE)
-				.producerCode(PRODUCER_CODE)
+				.producerCode(PRODUCER_CODE_LIST)
 				.systemCode(SYSTEM_CODE)
 				.description(DESCRIPTION)
 				.personalData(true)

--- a/data-catalog-backend-test/data-catalog-backend-test-component/src/test/java/no/nav/data/catalog/backend/test/component/informationtype/TestdataInformationTypes.java
+++ b/data-catalog-backend-test/data-catalog-backend-test-component/src/test/java/no/nav/data/catalog/backend/test/component/informationtype/TestdataInformationTypes.java
@@ -1,17 +1,19 @@
 package no.nav.data.catalog.backend.test.component.informationtype;
 
+import java.util.List;
 import java.util.Map;
 
 class TestdataInformationTypes {
 	static final String CATEGORY_CODE = "PERSONALIA";
 	static final String CATEGORY_DESCRIPTION = "Personalia";
-	static final Map<String, String> CATEGORY_MAP = Map.of("code", CATEGORY_CODE, "description", CATEGORY_DESCRIPTION);
-	static final String PRODUCER_CODE = "SKATTEETATEN";
-	static final String PRODUCER_DESCRIPTION = "Skatteetaten";
-	static final Map<String, String> PRODUCER_MAP = Map.of("code", PRODUCER_CODE, "description", PRODUCER_DESCRIPTION);
+	//	static final Map<String, String> CATEGORY_MAP = Map.of("code", CATEGORY_CODE, "description", CATEGORY_DESCRIPTION);
+	static final String PRODUCER_CODE_STRING = "SKATTEETATEN, BRUKER";
+	static final List<String> PRODUCER_CODE_LIST = List.of("SKATTEETATEN", "BRUKER");
+	static final List<String> PRODUCER_DESCRIPTION_LIST = List.of("Skatteetaten", "bruker");
+	//	static final Map<String, String> PRODUCER_MAP = Map.of("code", PRODUCER_CODE_STRING, "description", PRODUCER_DESCRIPTION_LIST);
 	static final String SYSTEM_CODE = "TPS";
 	static final String SYSTEM_DESCRIPTION = "Tjenestebasert PersondataSystem";
-	static final Map<String, String> SYSTEM_MAP = Map.of("code", SYSTEM_CODE, "description", SYSTEM_DESCRIPTION);
+	//	static final Map<String, String> SYSTEM_MAP = Map.of("code", SYSTEM_CODE, "description", SYSTEM_DESCRIPTION);
 	static final String NAME = "InformationName";
 	static final String DESCRIPTION = "InformationDescription";
 	static final String URL = "/backend/informationtype";

--- a/data-catalog-backend-test/data-catalog-backend-test-integration/src/test/java/no/nav/data/catalog/backend/test/integration/github/GithubWebhooksControllerIT.java
+++ b/data-catalog-backend-test/data-catalog-backend-test-integration/src/test/java/no/nav/data/catalog/backend/test/integration/github/GithubWebhooksControllerIT.java
@@ -75,10 +75,11 @@ public class GithubWebhooksControllerIT {
     }
 
     private void intializeCodelists() {
-        codelists = codelistService.codelists;
+		codelists = CodelistService.codelists;
         codelists.get(ListName.CATEGORY).put("PERSONALIA", "Personalia");
         codelists.get(ListName.CATEGORY).put("INNTEKT_YTELSER", "Inntekt, trygde- og pensjonsytelser");
         codelists.get(ListName.PRODUCER).put("SKATTEETATEN", "Skatteetaten");
+		codelists.get(ListName.PRODUCER).put("BRUKER", "Bruker");
         codelists.get(ListName.PRODUCER).put("UTLENDINGSDIREKTORATET", "Utlendingsdirektoratet");
         codelists.get(ListName.SYSTEM).put("TPS", "Tjenestebasert PersondataSystem");
         codelists.get(ListName.SYSTEM).put("PESYS", "Pensjonssystem");

--- a/data-catalog-backend-test/data-catalog-backend-test-integration/src/test/java/no/nav/data/catalog/backend/test/integration/informationtype/InformationTypeControllerIT.java
+++ b/data-catalog-backend-test/data-catalog-backend-test-integration/src/test/java/no/nav/data/catalog/backend/test/integration/informationtype/InformationTypeControllerIT.java
@@ -5,9 +5,11 @@ import static no.nav.data.catalog.backend.app.elasticsearch.ElasticsearchStatus.
 import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.CATEGORY_CODE;
 import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.CATEGORY_DESCRIPTION;
 import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.DESCRIPTION;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.LIST_PRODUCER_MAP;
 import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.NAME;
-import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.PRODUCER_CODE;
-import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.PRODUCER_DESCRIPTION;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.PRODUCER_CODE_LIST;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.PRODUCER_CODE_STRING;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.PRODUCER_DESCRIPTION_LIST;
 import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.SYSTEM_CODE;
 import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.SYSTEM_DESCRIPTION;
 import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.URL;
@@ -17,7 +19,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import no.nav.data.catalog.backend.app.AppStarter;
-import no.nav.data.catalog.backend.app.codelist.CodelistRepository;
 import no.nav.data.catalog.backend.app.codelist.CodelistService;
 import no.nav.data.catalog.backend.app.codelist.ListName;
 import no.nav.data.catalog.backend.app.informationtype.InformationType;
@@ -40,8 +41,6 @@ import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -101,7 +100,8 @@ public class InformationTypeControllerIT {
 	private void initializeCodelists() {
 		codelists = CodelistService.codelists;
 		codelists.get(ListName.CATEGORY).put(CATEGORY_CODE, CATEGORY_DESCRIPTION);
-		codelists.get(ListName.PRODUCER).put(PRODUCER_CODE, PRODUCER_DESCRIPTION);
+		codelists.get(ListName.PRODUCER).put(PRODUCER_CODE_LIST.get(0), PRODUCER_DESCRIPTION_LIST.get(0));
+		codelists.get(ListName.PRODUCER).put(PRODUCER_CODE_LIST.get(1), PRODUCER_DESCRIPTION_LIST.get(1));
 		codelists.get(ListName.SYSTEM).put(SYSTEM_CODE, SYSTEM_DESCRIPTION);
 	}
 
@@ -255,7 +255,7 @@ public class InformationTypeControllerIT {
 	}
 
 	private void assertInformationType(InformationType informationType) {
-		assertThat(informationType.getProducerCode(), is(PRODUCER_CODE));
+		assertThat(informationType.getProducerCode(), is(PRODUCER_CODE_STRING));
 		assertThat(informationType.getSystemCode(), is(SYSTEM_CODE));
 		assertThat(informationType.isPersonalData(), is(true));
 		assertThat(informationType.getName(), is(NAME));
@@ -268,8 +268,7 @@ public class InformationTypeControllerIT {
 		assertThat(response.getDescription(), equalTo(DESCRIPTION));
 		assertThat(response.getCategory().get("code"), equalTo(CATEGORY_CODE));
 		assertThat(response.getCategory().get("description"), equalTo(CATEGORY_DESCRIPTION));
-		assertThat(response.getProducer().get("code"), equalTo(PRODUCER_CODE));
-		assertThat(response.getProducer().get("description"), equalTo(PRODUCER_DESCRIPTION));
+		assertThat(response.getProducer(), equalTo(LIST_PRODUCER_MAP));
 		assertThat(response.getSystem().get("code"), equalTo(SYSTEM_CODE));
 		assertThat(response.getSystem().get("description"), equalTo(SYSTEM_DESCRIPTION));
 	}
@@ -286,7 +285,7 @@ public class InformationTypeControllerIT {
 				.name(name)
 				.description(DESCRIPTION)
 				.categoryCode(CATEGORY_CODE)
-				.producerCode(PRODUCER_CODE)
+				.producerCode(PRODUCER_CODE_LIST)
 				.systemCode(SYSTEM_CODE)
 				.personalData(true)
 				.build();

--- a/data-catalog-backend-test/data-catalog-backend-test-integration/src/test/java/no/nav/data/catalog/backend/test/integration/informationtype/InformationTypeServiceIT.java
+++ b/data-catalog-backend-test/data-catalog-backend-test-integration/src/test/java/no/nav/data/catalog/backend/test/integration/informationtype/InformationTypeServiceIT.java
@@ -1,7 +1,18 @@
 package no.nav.data.catalog.backend.test.integration.informationtype;
 
-import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.*;
 import static no.nav.data.catalog.backend.app.elasticsearch.ElasticsearchStatus.SYNCED;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.CATEGORY_CODE;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.CATEGORY_DESCRIPTION;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.CATEGORY_MAP;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.DESCRIPTION;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.LIST_PRODUCER_MAP;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.NAME;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.PRODUCER_CODE_LIST;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.PRODUCER_CODE_STRING;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.PRODUCER_DESCRIPTION_LIST;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.SYSTEM_CODE;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.SYSTEM_DESCRIPTION;
+import static no.nav.data.catalog.backend.test.integration.informationtype.TestdataInformationTypes.SYSTEM_MAP;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -79,7 +90,8 @@ public class InformationTypeServiceIT {
     private void initializeCodelists() {
         codelists = CodelistService.codelists;
         codelists.get(ListName.CATEGORY).put(CATEGORY_CODE, CATEGORY_DESCRIPTION);
-        codelists.get(ListName.PRODUCER).put(PRODUCER_CODE, PRODUCER_DESCRIPTION);
+        codelists.get(ListName.PRODUCER).put(PRODUCER_CODE_LIST.get(0), PRODUCER_DESCRIPTION_LIST.get(0));
+        codelists.get(ListName.PRODUCER).put(PRODUCER_CODE_LIST.get(1), PRODUCER_DESCRIPTION_LIST.get(1));
         codelists.get(ListName.SYSTEM).put(SYSTEM_CODE, SYSTEM_DESCRIPTION);
     }
 
@@ -164,7 +176,7 @@ public class InformationTypeServiceIT {
                 .elasticsearchStatus(esStatus)
                 .name(NAME)
                 .description(DESCRIPTION)
-                .producerCode(PRODUCER_CODE)
+                .producerCode(PRODUCER_CODE_STRING)
                 .personalData(true).build();
         repository.save(informationType);
     }
@@ -184,8 +196,8 @@ public class InformationTypeServiceIT {
         assertThat(esMap.get("name"), is(NAME));
         assertThat(esMap.get("description"), is(DESCRIPTION));
         assertThat(esMap.get("personalData"), is(true));
-        assertThat((Map) esMap.get("category"), is(CATEGORY_MAP));
-        assertThat((Map) esMap.get("producer"), is(PRODUCER_MAP));
-        assertThat((Map) esMap.get("system"), is(SYSTEM_MAP));
+        assertThat(esMap.get("category"), is(CATEGORY_MAP));
+        assertThat(esMap.get("producer"), is(LIST_PRODUCER_MAP));
+        assertThat(esMap.get("system"), is(SYSTEM_MAP));
     }
 }

--- a/data-catalog-backend-test/data-catalog-backend-test-integration/src/test/java/no/nav/data/catalog/backend/test/integration/informationtype/TestdataInformationTypes.java
+++ b/data-catalog-backend-test/data-catalog-backend-test-integration/src/test/java/no/nav/data/catalog/backend/test/integration/informationtype/TestdataInformationTypes.java
@@ -1,14 +1,18 @@
 package no.nav.data.catalog.backend.test.integration.informationtype;
 
+import java.util.List;
 import java.util.Map;
 
 class TestdataInformationTypes {
 	static final String CATEGORY_CODE = "PERSONALIA";
 	static final String CATEGORY_DESCRIPTION = "Personalia";
 	static final Map<String, String> CATEGORY_MAP = Map.of("code", CATEGORY_CODE, "description", CATEGORY_DESCRIPTION);
-	static final String PRODUCER_CODE = "SKATTEETATEN";
-	static final String PRODUCER_DESCRIPTION = "Skatteetaten";
-	static final Map<String, String> PRODUCER_MAP = Map.of("code", PRODUCER_CODE, "description", PRODUCER_DESCRIPTION);
+	static final String PRODUCER_CODE_STRING = "SKATTEETATEN, BRUKER";
+	static final List<String> PRODUCER_CODE_LIST = List.of("SKATTEETATEN", "BRUKER");
+	static final List<String> PRODUCER_DESCRIPTION_LIST = List.of("Skatteetaten", "Bruker");
+	static final List<Map> LIST_PRODUCER_MAP = List.of(
+			Map.of("code", PRODUCER_CODE_LIST.get(0), "description", PRODUCER_DESCRIPTION_LIST.get(0)),
+			Map.of("code", PRODUCER_CODE_LIST.get(1), "description", PRODUCER_DESCRIPTION_LIST.get(1)));
 	static final String SYSTEM_CODE = "AA_REG";
 	static final String SYSTEM_DESCRIPTION = "Arbeidsgiver / Arbeidstaker register";
 	static final Map<String, String> SYSTEM_MAP = Map.of("code", SYSTEM_CODE, "description", SYSTEM_DESCRIPTION);


### PR DESCRIPTION
InformationType feltet producer er nå en kommaseparert streng av producerCodes. 
InformationTypeRequest bruker er en liste av producerCodes (strenger) men heter fortsatt producerCode.
InformationTypeResponse er en liste over en maps av producer slik;
producer: [
{"code": "xxx", "description": "yyy"},
{"code": "aaa", "description": "bbb"}
]

Fixes #43 
